### PR TITLE
Include path component of endpoint_url in the hawk signature

### DIFF
--- a/loadtest.py
+++ b/loadtest.py
@@ -121,6 +121,7 @@ class StorageClient(object):
 
         url = urlparse(self.endpoint_url)
         self.endpoint_scheme = url.scheme
+        self.endpoint_path = url.path
         if ':' in url.netloc:
             self.endpoint_host, self.endpoint_port = url.netloc.rsplit(":", 1)
         else:
@@ -136,7 +137,7 @@ class StorageClient(object):
         bits.append(params["ts"])
         bits.append(params["nonce"])
         bits.append(meth)
-        bits.append(path_qs)
+        bits.append(self.endpoint_path + path_qs)
         bits.append(self.endpoint_host.lower())
         bits.append(self.endpoint_port)
         bits.append(params.get("hash", ""))


### PR DESCRIPTION
The `endpoint_url` returned by tokenserver can include a path component, which we have to make sure to include in the Hawk signature.  With this change a `molotov -r 1 loadtest.py` runs successfully for me.