### PR TITLE
feat: port delete requests from the old stress.py

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -242,3 +242,6 @@ class StorageClient(object):
     async def get(self, path_qs, statuses=None, params=None):
         return await self._retry('GET', path_qs, params, data=None,
                                  statuses=statuses)
+
+    async def delete(self, path_qs, data=None, statuses=None, params=None):
+        return await self._retry('DELETE', path_qs, params, data, statuses)


### PR DESCRIPTION
with the ability to disable via env var: DISABLE_DELETES=true

also fix get_num_requests' weight lookup

Closes #12