### PR TITLE
feat: Respect remote servers configuration limits

### DIFF
--- a/loadtest.py
+++ b/loadtest.py
@@ -71,13 +71,13 @@ async def test(session):
 
     # Respect the server limits.
     _, config = await storage.get("/info/configuration")
-    print("Config: {}".format(json.dumps(config, indent=3)))
+    # print("Config: {}".format(json.dumps(config, indent=3)))
     # fix up consts
     payload = _PAYLOAD[:config.get("max_record_payload_bytes")]
     # GET requests to meta/global
     num_requests = min(get_num_requests('metaglobal'),
                        config.get("max_post_records"))
-    batch_max_count = min(BATCH_MAX_COUNT, config.get("max_total_records"))
+    batch_max_count = min(_BATCH_MAX_COUNT, config.get("max_total_records"))
 
     # Always GET info/collections
     # This is also a good opportunity to correct for timeskew.

--- a/loadtest.py
+++ b/loadtest.py
@@ -69,19 +69,27 @@ async def _session(worker_num, session):
 async def test(session):
     storage = session.storage
 
+    # Respect the server limits.
+    _, config = await storage.get("/info/configuration")
+    print("Config: {}".format(json.dumps(config, indent=3)))
+    # fix up consts
+    payload = _PAYLOAD[:config.get("max_record_payload_bytes")]
+    # GET requests to meta/global
+    num_requests = min(get_num_requests('metaglobal'),
+                       config.get("max_post_records"))
+    batch_max_count = min(BATCH_MAX_COUNT, config.get("max_total_records"))
+
     # Always GET info/collections
     # This is also a good opportunity to correct for timeskew.
     url = "/info/collections"
-    await storage.get(url, (200, 404))
+    resp, _ = await storage.get(url, (200, 404))
 
-    # GET requests to meta/global
-    num_requests = get_num_requests('metaglobal')
     url = "/storage/meta/global"
 
     for x in range(num_requests):
         resp, __ = await storage.get(url, (200, 404))
         if resp.status == 404:
-            data = json.dumps({"id": "global", "payload": _PAYLOAD})
+            data = json.dumps({"id": "global", "payload": payload})
             await storage.put(url, data=data, statuses=(200,))
 
     # Occasional reads of client records.
@@ -98,8 +106,8 @@ async def test(session):
         wbo = {'id': 'client' + cid, 'payload': cid * 300}
         data = json.dumps([wbo])
         resp, result = await storage.post(url, data=data, statuses=(200,))
-        assert len(result["success"]) == 1
-        assert len(result["failed"]) == 0
+        assert len(result["success"]) == 1, "No success records"
+        assert len(result["failed"]) == 0, "Found failed record"
 
     # GET requests to individual collections.
     num_requests = get_num_requests('count_distribution')
@@ -128,16 +136,18 @@ async def test(session):
         url = "/storage/" + cols[x]
         data = []
         # Random batch size, skewed slightly towards the upper limit.
-        items_per_batch = min(random.randint(20, _BATCH_MAX_COUNT + 80),
-                              _BATCH_MAX_COUNT)
-        for i in range(items_per_batch):
+        items_per_batch = min(random.randint(20, batch_max_count + 80),
+                              batch_max_count)
+        for _i in range(items_per_batch):
             randomness = os.urandom(10)
             id = base64.urlsafe_b64encode(randomness).rstrip(b"=")
             id = id.decode('utf8')
             id += str(int((time.time() % 100) * 100000))
             # Random payload length.  They can be big, but skew small.
-            # This gives min=300, mean=450, max=7000
-            payload_length = min(int(random.paretovariate(3) * 300), 7000)
+            # This gives min=300, mean=450, max=config.max_record_payload_bytes
+            payload_length = min(
+                int(random.paretovariate(3) * 300),
+                config.get("max_record_payload_bytes"))
 
             # XXX should be in the class
             token = storage.auth_token.decode('utf8')
@@ -164,8 +174,13 @@ async def test(session):
                 url += "?batch=%s" % batch_id
 
         resp, result = await storage.post(url, data=data, statuses=(status,))
-        assert len(result["success"]) == items_per_batch, result
-        assert len(result["failed"]) == 0, result
+        assert len(result["success"]) == items_per_batch, (
+            "Result success did not have expected number of"
+            "items in batch {}".format(result)
+        )
+        assert len(result["failed"]) == 0, (
+            "Result contained failed records: {}".format(result)
+        )
 
         if transact and not committing:
             batch_id = result["batch"]

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -141,7 +141,7 @@ class StorageClient(object):
 
         # Regenerate tokens when they're close to expiring
         # but before they actually expire, to avoid spurious 401s.
-        
+
         self.auth_expires_at = time.time() + (token_duration * 0.5)
 
         url = urlparse(self.endpoint_url)
@@ -222,12 +222,20 @@ class StorageClient(object):
                 options['headers']['Authorization'] = self._auth(meth, url)
                 async with call(url, **options) as resp:
                     if statuses is not None:
-                        assert resp.status in statuses, resp.status
+                        assert resp.status in statuses, (
+                            "Reauth Response {} not in {}".format(
+                                resp.status,
+                                statuses)
+                        )
                     body = await resp.json()
                     return resp, body
             else:
                 if statuses is not None:
-                    assert resp.status in statuses, statuses
+                    assert resp.status in statuses,  (
+                            "Response {} not in {}".format(
+                                resp.status,
+                                statuses)
+                        )
 
                 body = await resp.json()
                 return resp, body


### PR DESCRIPTION
also `assert` is the anti-christ, so make the errors more meaningful
than `(202,)`

Closes #19