### PR TITLE
Update README to explicitly say Python 3.6+ (per Molotov 2.x requirements)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Storage load test
 -----------------
-* Note: this requires Python version 3.5 or 3.6
+* Note: this requires Python version 3.6+
 
 To run it locally::
 
@@ -9,7 +9,7 @@ To run it locally::
     $ bin/molotov --max-runs 5 -cxv loadtest.py
 
 
-To run it locally, directly from Github (assuming Molotov is installed)::
+To run it locally, directly from GitHub (assuming Molotov is installed)::
 
     $ moloslave https://github.com/mozilla-services/syncstorage-loadtest test
 


### PR DESCRIPTION
Fixes #25 

Per https://github.com/loads/molotov README file:

> Simple Python 3.6+ tool to write load tests.