### PR TITLE
Add aiodogstatsd to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyBrowserID
 hawkauthlib
 tokenlib
 aiomeasures
+aiodogstatsd


### PR DESCRIPTION
Fixes #26 

Both @rpappalax and I had to do this change locally to try running the examples in the README.

Not sure if this fix belongs in this repo [and every other molotov load test project] or if it's something that needs to be addressed in molotov core (/cc @tarekziade).

```sh
molotov --version

Traceback (most recent call last):
  File "/Volumes/Dev/tmp/sync-loadtests-tmp/venv/bin/molotov", line 5, in <module>
    from molotov.run import main
  File "/Volumes/Dev/tmp/sync-loadtests-tmp/venv/lib/python3.7/site-packages/molotov/run.py", line 9, in <module>
    from molotov.runner import Runner
  File "/Volumes/Dev/tmp/sync-loadtests-tmp/venv/lib/python3.7/site-packages/molotov/runner.py", line 9, in <module>
    from molotov.stats import get_statsd_client
  File "/Volumes/Dev/tmp/sync-loadtests-tmp/venv/lib/python3.7/site-packages/molotov/stats.py", line 2, in <module>
    from aiodogstatsd import Client
ModuleNotFoundError: No module named 'aiodogstatsd'
```
