### PR TITLE
feat: Add Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Mozilla AutoPush Load-Tester
+
+# SyncStorage-LoadTest
+#
+FROM python:3-slim
+
+RUN mkdir -p /app
+ADD . /app
+WORKDIR /app
+
+# Building:
+# you can build a local docker image using
+# `docker build . --tag syncstorage-loadtest:local`
+
+# system setup
+RUN \
+    BUILD_DEPS="git build-essential" && \
+    # wget not required but nice to have
+    RUN_DEPS="wget libssl-dev" && \
+    apt-get update && \
+    apt-get install -yq --no-install-recommends ${BUILD_DEPS} ${RUN_DEPS} && \
+    pip install virtualenv && \
+    python -m virtualenv -p `which python` apenv
+
+# app install
+RUN \
+    ./apenv/bin/pip install pyasn1 && \
+    ./apenv/bin/pip install -r requirements.txt && \
+    apt-get purge -yq --auto-remove ${BUILD_DEPS} && \
+    apt-get autoremove -yqq && \
+    apt-get clean -y
+
+# Using:
+# Start an interactive terminal using
+# `docker run --net=host -it syncstorage-loadtest:local`
+# This will start a bash shell as root.
+# You can fire off a load test by calling:
+# `SERVER_URL=http://${HOST}:${PORT}#${SECRET} ./apenv/bin/molotov -v`
+
+ENTRYPOINT ["/bin/bash"]

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,7 @@
+#! /bin/bash -xe
+# the Sync server URL. (Presumes a locally running server.)
+# *NOTE* this will use the first arg, but will default to `localhost:8000`
+HOST=${1:-http://localhost:8000}
+# The sync shared secret.
+SECRET=${2:-secret0}
+SERVER_URL=${HOST}#${SECRET} apenv/bin/molotov --processes 2 --workers 149 --verbose


### PR DESCRIPTION
## Description

Python can get a bit finicky with configurations and requirements.
Adding a Dockerfile to allow for a potentially consistent environment
which can run the load tests.

See `Dockerfile` for hints on how to run and use the image.

## Testing

See `Dockerfile` for hints.
This should build a docker image which allows folk to run a load test.

## Issue(s)

Closes #33

