### PR TITLE
feat: use OAuth JWTs instead of BrowserID

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,54 @@ Storage load test
 -----------------
 * Note: this requires Python version 3.6+
 
+The tests can execute in three modes:
+
+1. **Direct access**: use a known master secret
+2. **Firefox accounts OAuth**: create test accounts and use OAuth JWTs
+3. **Self-signed JWT**: generate and sign JWTs locally with a given private key
+
+
 To run it locally::
 
-    $ virtualenv .
-    $ bin/pip install -r requirements.txt
-    $ bin/molotov --max-runs 5 -cxv loadtest.py
+    $ pip install -r requirements.txt
+
+Mode 1: Direct Access
+~~~~~~~~~~~~~~~~~~~~~
+
+With a known syncstorage master secret::
+
+    $ SERVER_URL="http://localhost:8000#secretValue" molotov --max-runs 5 -cxv loadtest.py
+
+Mode 2: Firefox Accounts OAuth
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With FxA stage accounts::
+
+    $ SERVER_URL="https://token.stage.mozaws.net" \
+      FXA_API_HOST="https://api-accounts.stage.mozaws.net" \
+      FXA_OAUTH_HOST="https://oauth.stage.mozaws.net" \
+      molotov --workers 3 --duration 60 -v loadtest.py
+
+Mode 3: Self-Signed JWTs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Assuming an RSA keypair was generated, the private key pem was saved and
+accessible, and the token server was started with the public key JWK
+configured.  The presence of OAUTH_PRIVATE_KEY_FILE triggers this mode when
+using OAuth.
+
+Run with self-signed JWTs::
+
+    $ SERVER_URL="http://localhost:8000" \
+      OAUTH_PRIVATE_KEY_FILE="/path/to/load_test.pem" \
+      molotov --workers 100 --duration 300 -v loadtest.py
 
 
-To run it locally, directly from GitHub (assuming Molotov is installed)::
-
-    $ moloslave https://github.com/mozilla-services/syncstorage-loadtest test
-
-See the molotov.json file for the different tests available to moloslave
+Docker
+~~~~~~
 
 To run it inside docker::
 
     $ docker run -e TEST_REPO=https://github.com/mozilla-services/syncstorage-loadtest -e TEST_NAME=test tarekziade/molotov:latest
-
 
 Happy Breaking!

--- a/cleanup_orphaned_accounts.py
+++ b/cleanup_orphaned_accounts.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""
+Cleanup orphaned accounts from interrupted tests.
+
+Usage:
+    python cleanup_orphaned_accounts.py
+"""
+
+import os
+import json
+from fxa.core import Client
+from fxa.errors import ClientError, ServerError
+
+ACCT_TRACKING_FILE = os.path.join(os.path.dirname(__file__), '.accounts_tracking.json')
+FXA_API_HOST = os.environ.get("FXA_API_HOST", "https://api-accounts.stage.mozaws.net")
+
+
+def load_tracked_accounts():
+    if not os.path.exists(ACCT_TRACKING_FILE):
+        return []
+
+    try:
+        with open(ACCT_TRACKING_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"Warning: Could not load tracking file: {e}")
+        return []
+
+
+def save_tracked_accounts(accounts):
+    try:
+        if not accounts:
+            if os.path.exists(ACCT_TRACKING_FILE):
+                os.remove(ACCT_TRACKING_FILE)
+        else:
+            with open(ACCT_TRACKING_FILE, 'w') as f:
+                json.dump(accounts, f, indent=2)
+    except IOError as e:
+        print(f"Warning: Could not save tracking file: {e}")
+
+
+def remove_account_from_tracking(email):
+    accounts = load_tracked_accounts()
+    accounts = [acc for acc in accounts if acc['email'] != email]
+    save_tracked_accounts(accounts)
+
+
+def cleanup_account(client, account):
+    email = account['email']
+    password = account['password']
+
+    try:
+        client.destroy_account(email, password)
+        print(f"  ✓ Deleted: {email}")
+        return True
+    except (ServerError, ClientError) as ex:
+        print(f"  ✗ Delete failed: {email} - {ex}")
+        return False
+    except Exception as ex:
+        print(f"  ✗ Delete error: {email} - {ex}")
+        return False
+
+
+def cleanup_all_accounts():
+    accounts = load_tracked_accounts()
+
+    if not accounts:
+        print("No accounts to clean up.")
+        return 0, 0
+
+    print(f"\nFound {len(accounts)} accounts")
+    print("\nAttempting to delete accounts...\n")
+
+    client = Client(FXA_API_HOST)
+    successful = 0
+    failed = 0
+
+    for account in accounts:
+        if cleanup_account(client, account):
+            successful += 1
+            remove_account_from_tracking(account['email'])
+        else:
+            failed += 1
+
+    print(f"\nResults: {successful} deleted, {failed} failed")
+
+    return successful, failed
+
+
+def main():
+    cleanup_all_accounts()
+
+
+if __name__ == "__main__":
+    main()

--- a/cleanup_orphaned_accounts.py
+++ b/cleanup_orphaned_accounts.py
@@ -37,7 +37,7 @@ def save_tracked_accounts(accounts):
                 json.dump(accounts, f, indent=2)
     except IOError as e:
         print(f"Warning: Could not save tracking file: {e}")
-
+        raise
 
 def remove_account_from_tracking(email):
     accounts = load_tracked_accounts()

--- a/loadtest.py
+++ b/loadtest.py
@@ -6,7 +6,7 @@ import random
 import json
 
 from storage import StorageClient
-from molotov import setup_session, scenario
+from molotov import setup_session, teardown_session, scenario
 
 
 _PAYLOAD = """\
@@ -63,6 +63,12 @@ async def _session(worker_num, session):
     t.join()
     if len(exc) > 0:
         raise exc[0]
+
+
+@teardown_session()
+async def _teardown_session(worker_num, session):
+    if hasattr(session, 'storage') and session.storage:
+        session.storage.cleanup()
 
 
 @scenario(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-git+git://github.com/loads/molotov.git
+git+https://github.com/tarekziade/molotov.git
 pexpect
 configparser==3.5.0b2
-PyBrowserID
 hawkauthlib
 tokenlib
 aiodogstatsd
+PyFxA
+PyJWT
+cryptography

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,46 +1,234 @@
 import os
 import hmac
 import random
+import string
 import time
 from urllib.parse import urlparse, urlunparse, urlencode
 import base64
 import hashlib
+import json
+from pathlib import Path
 
 from tokenlib import make_token, get_derived_secret as derive
-import browserid.jwt
-import browserid.tests.support
 from molotov import json_request
+from fxa.core import Client
+from fxa.oauth import Client as OAuthClient
+from fxa.tests.utils import TestEmailAccount
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
 
+
+# Client ID for Firefox Desktop
+CLIENT_ID = "5882386c6d801776"
+FXA_API_HOST = os.environ.get("FXA_API_HOST", "https://api-accounts.stage.mozaws.net")
+FXA_OAUTH_HOST = os.environ.get("FXA_OAUTH_HOST", "https://oauth.stage.mozaws.net")
+OAUTH_SCOPE = "https://identity.mozilla.com/apps/oldsync"
+PASSWORD_LENGTH = 20
 
 # Assertions are good for one year (in seconds).
 # This avoids having to deal with clock-skew in tokenserver requests.
 ASSERTION_LIFETIME = 60 * 60 * 24 * 365
 
-MOCKMYID_DOMAIN = "mockmyid.s3-us-west-2.amazonaws.com"
-MOCKMYID_PRIVATE_KEY = browserid.jwt.DS128Key({
-    "algorithm": "DS",
-    "x": "385cb3509f086e110c5e24bdd395a84b335a09ae",
-    "y": "738ec929b559b604a232a9b55a5295afc368063bb9c20fac4e53a74970a4db795"
-         "6d48e4c7ed523405f629b4cc83062f13029c4d615bbacb8b97f5e56f0c7ac9bc1"
-         "d4e23809889fa061425c984061fca1826040c399715ce7ed385c4dd0d40225691"
-         "2451e03452d3c961614eb458f188e3e8d2782916c43dbe2e571251ce38262",
-    "p": "ff600483db6abfc5b45eab78594b3533d550d9f1bf2a992a7a8daa6dc34f8045a"
-         "d4e6e0c429d334eeeaaefd7e23d4810be00e4cc1492cba325ba81ff2d5a5b305a"
-         "8d17eb3bf4a06a349d392e00d329744a5179380344e82a18c47933438f891e22a"
-         "eef812d69c8f75e326cb70ea000c3f776dfdbd604638c2ef717fc26d02e17",
-    "q": "e21e04f911d1ed7991008ecaab3bf775984309c3",
-    "g": "c52a4a0ff3b7e61fdf1867ce84138369a6154f4afa92966e3c827e25cfa6cf508b"
-         "90e5de419e1337e07a2e9e2a3cd5dea704d175f8ebf6af397d69e110b96afb17c7"
-         "a03259329e4829b0d03bbc7896b15b4ade53e130858cc34d96269aa89041f40913"
-         "6c7242a38895c9d5bccad4f389af1d7a4bd1398bd072dffa896233397a",
-})
-
+# OAuth JWT signing to test without FxA
+OAUTH_PRIVATE_KEY_FILE = os.environ.get("OAUTH_PRIVATE_KEY_FILE")
+OAUTH_ISSUER = os.environ.get("OAUTH_ISSUER", "http://mock-fxa-server:6000")
+OAUTH_JWT_ALGORITHM = os.environ.get("OAUTH_JWT_ALGORITHM", "RS256")
 
 _DEFAULT = os.environ.get("SERVER_URL", "https://token.stage.mozaws.net")
+_ACCT_TRACKING_FILE = Path(__file__).parent.parent / '.accounts_tracking.json'
 
 
 def b64encode(data):
     return base64.b64encode(data).decode("ascii")
+
+
+def _generate_password():
+    return "".join(random.choice(string.printable) for i in range(PASSWORD_LENGTH))
+
+
+def _track_account_creation(email, password, fxa_uid):
+    try:
+        if _ACCT_TRACKING_FILE.exists():
+            with open(_ACCT_TRACKING_FILE, 'r') as f:
+                accounts = json.load(f)
+        else:
+            accounts = []
+
+        for acc in accounts:
+            # already tracked
+            if acc['email'] == email:
+                return 
+
+        accounts.append({
+            'email': email,
+            'password': password,
+            'fxa_uid': fxa_uid,
+            'created_at': int(time.time())
+        })
+
+        with open(_ACCT_TRACKING_FILE, 'w') as f:
+            json.dump(accounts, f, indent=2)
+
+    except Exception:
+        # continue with tests
+        pass
+
+
+def _remove_account_from_tracking(email):
+    try:
+        if not _ACCT_TRACKING_FILE.exists():
+            return
+
+        with open(_ACCT_TRACKING_FILE, 'r') as f:
+            accounts = json.load(f)
+
+        accounts = [acc for acc in accounts if acc['email'] != email]
+
+        if not accounts:
+            _ACCT_TRACKING_FILE.unlink()
+        else:
+            with open(_ACCT_TRACKING_FILE, 'w') as f:
+                json.dump(accounts, f, indent=2)
+
+    except Exception:
+        pass
+
+
+def _create_self_signed_jwt(email, client_id=CLIENT_ID):
+    """
+    Create a self-signed OAuth JWT.  Requires OAUTH_PRIVATE_KEY_FILE env var.
+
+    Returns tuple of:
+        - oauth_token: Self-signed JWT
+        - email: Email address
+        - fxa_uid: Generated FxA uid
+        - key_id: Key id
+        - None: FxA session not needed
+        - None: OAuth client not needed
+        - None: cleanup info not needed
+    """
+    if not OAUTH_PRIVATE_KEY_FILE:
+        raise ValueError("OAUTH_PRIVATE_KEY_FILE must be set")
+
+    with open(OAUTH_PRIVATE_KEY_FILE, 'rb') as f:
+        private_key = serialization.load_pem_private_key(
+            f.read(),
+            password=None,
+            backend=default_backend()
+        )
+
+    # fake fxa uid
+    fxa_uid = hashlib.sha256(email.encode()).hexdigest()[:32]
+
+    # JWT payload
+    now = int(time.time())
+    payload = {
+        'sub': fxa_uid,
+        'scope': OAUTH_SCOPE,
+        'fxa-generation': 0,
+        'client_id': client_id,
+        'iat': now,
+        'exp': now + (12 * 3600),
+        'iss': OAUTH_ISSUER,
+    }
+
+    # sign JWT
+    oauth_token = jwt.encode(payload, private_key, algorithm=OAUTH_JWT_ALGORITHM, headers={"typ": "application/at+jwt"})
+
+    key_id = "1234-qqo"
+
+    if os.environ.get("DEBUG_OAUTH"):
+        print(f"DEBUG: Created self-signed JWT for: {email} / {fxa_uid}")
+
+    return oauth_token, email, fxa_uid, key_id, None, None, None
+
+
+def _is_oauth_token_expired(oauth_token, buffer_seconds=300):
+    """
+    Check if an OAuth token is expired or will expire soon.
+
+    :param oauth_token: JWT
+    :param buffer_seconds: Consider token expired if it expires within this many seconds
+    :returns: True if token is expired or will expire soon, False otherwise
+    """
+    try:
+        decoded = jwt.decode(oauth_token, options={"verify_signature": False})
+        exp = decoded.get('exp')
+
+        if exp is None:
+            return False
+
+        current_time = time.time()
+        return current_time >= (exp - buffer_seconds)
+
+    except Exception:
+        return True
+
+
+def _create_fxa_account():
+    """
+    Create account credentials.
+
+    If OAUTH_PRIVATE_KEY_FILE is provided, creates self-signed JWT. Otherwise,
+    creates real, testing account via FxA API.  The account is deleted at the
+    end of the test.
+
+    Returns tuple of:
+        - oauth_token: OAuth access token
+        - acct_email: Account email address
+        - fxa_uid: FxA uid
+        - key_id: Key id
+        - fxa_session: FxA session, or None for self-signed
+        - oauth_client: OAuthClient instance, or None for self-signed
+        - cleanup_info: Dict with cleanup info, or None for self-signed
+    """
+
+    if OAUTH_PRIVATE_KEY_FILE:
+        email = f"molotov-{int(time.time())}-{random.randint(1000, 9999)}@example.com"
+        return _create_self_signed_jwt(email)
+
+    # use FxA to create account and fetch JWT
+    acct = TestEmailAccount()
+    client = Client(FXA_API_HOST)
+    oauth_client = OAuthClient(CLIENT_ID, None, server_url=FXA_OAUTH_HOST)
+    fxa_password = _generate_password()
+    session = client.create_account(acct.email, password=fxa_password)
+
+    # wait for account verification email
+    max_retries = 20
+    for _ in range(max_retries):
+        if acct.messages:
+            break
+        time.sleep(0.5)
+        acct.fetch()
+
+    if not acct.messages:
+        raise ValueError("Failed to receive FxA verification email")
+
+    # verify account with code
+    verified = False
+    for m in acct.messages:
+        if "x-verify-code" in m["headers"]:
+            session.verify_email_code(m["headers"]["x-verify-code"])
+            verified = True
+            break
+
+    if not verified:
+        raise ValueError("Failed to find verification code in email")
+
+    oauth_token = oauth_client.authorize_token(session, OAUTH_SCOPE)
+    key_id = "1234-qqo"
+    cleanup_info = {
+        'client': client,
+        'acct': acct,
+        'email': acct.email,
+        'password': fxa_password
+    }
+
+    _track_account_creation(acct.email, fxa_password, session.uid)
+
+    return oauth_token, acct.email, session.uid, key_id, session, oauth_client, cleanup_info
 
 
 class StorageClient(object):
@@ -56,6 +244,12 @@ class StorageClient(object):
         self.endpoint_url = None
         self.endpoint_scheme = None
         self.endpoint_host = None
+        self.fxa_oauth_token = None
+        self.fxa_uid = None
+        self.fxa_key_id = None
+        self.fxa_session = None  # For getting new OAuth tokens
+        self.fxa_oauth_client = None  # For getting new OAuth tokens
+        self.fxa_cleanup_info = None  # For account deletion
         self.generate()
 
     def _get_url(self, path, params=None):
@@ -68,17 +262,36 @@ class StorageClient(object):
         return str(self.auth_token)
 
     def generate(self):
-        """Pick an identity, log in and generate the auth token."""
-        self.uid = random.randint(1, 1000000)
+        """
+        Pick an identity, log in and generate the auth token.
+        For OAuth: Creates FxA account once and caches credentials.
+        """
+        url = urlparse(self.server_url)
+
+        if url.fragment:
+            self.uid = random.randint(1, 1000000)
+        else:
+            if self.fxa_oauth_token is None:
+                oauth_token, acct_email, fxa_uid, key_id, fxa_session, oauth_client, cleanup_info = _create_fxa_account()
+                self.fxa_oauth_token = oauth_token
+                self.fxa_uid = fxa_uid
+                self.fxa_key_id = key_id
+                self.fxa_session = fxa_session
+                self.fxa_oauth_client = oauth_client
+                self.fxa_cleanup_info = cleanup_info
+                if os.environ.get("DEBUG_OAUTH"):
+                    print(f"DEBUG: Created FxA account: {acct_email} / {fxa_uid}")
+
         self.regenerate()
 
     def regenerate(self):
         """Generate an auth token for the selected identity."""
         # If the server_url has a hash fragment, it's a storage node and
         # that's the secret.  Otherwise it's a token server url.
-        uid = self.uid
         url = urlparse(self.server_url)
+
         if url.fragment:
+            uid = self.uid
             endpoint = url._replace(
                 path=url.path.rstrip("/") + "/1.5/" + str(uid),
                 fragment="",
@@ -101,39 +314,57 @@ class StorageClient(object):
             self.auth_secret = derive(auth_token, secret=url.fragment).encode("ascii")
             self.auth_expires_at = data["expires"]
         else:
-            email = "user%s@%s" % (uid, MOCKMYID_DOMAIN)
-            exp = time.time() + ASSERTION_LIFETIME + self.timeskew
-            assertion = browserid.tests.support.make_assertion(
-                email=email,
-                audience=urlunparse(url._replace(path="")),
-                issuer=MOCKMYID_DOMAIN,
-                issuer_keypair=(None, MOCKMYID_PRIVATE_KEY),
-                exp=int(exp * 1000),
-            )
             token_url = self.server_url + "/1.0/sync/1.5"
+
+            if _is_oauth_token_expired(self.fxa_oauth_token):
+                if os.environ.get("DEBUG_OAUTH"):
+                    print(f"DEBUG: OAuth token expired, fetching another for account: {self.fxa_uid}")
+
+                # handle self-signed but really should just set a longer TTL?
+                if OAUTH_PRIVATE_KEY_FILE:
+                    email = f"loadtest-{self.fxa_uid}@example.com"
+                    new_oauth_token, _, _, _, _, _, _ = _create_self_signed_jwt(email)
+                    self.fxa_oauth_token = new_oauth_token
+                else:
+                    new_oauth_token = self.fxa_oauth_client.authorize_token(
+                        self.fxa_session,
+                        OAUTH_SCOPE
+                    )
+                    self.fxa_oauth_token = new_oauth_token
+
+                if os.environ.get("DEBUG_OAUTH"):
+                    print(f"DEBUG: fetched new token for account: {self.fxa_uid}")
+
+            oauth_token = self.fxa_oauth_token
+            fxa_uid = self.fxa_uid
+            key_id = self.fxa_key_id
+
+            if os.environ.get("DEBUG_OAUTH"):
+                print(f"DEBUG: Using existing OAuth token for account: {fxa_uid}")
+
             response = json_request(token_url, headers={
-                "Authorization": "BrowserID " + assertion,
+                "Authorization": "Bearer {}".format(oauth_token),
+                "X-KeyID": key_id,
             })
-            # Maybe timeskew between client and server?
-            if response['status'] == 401:
-                server_time = int(response['headers']["X-Timestamp"])
-                self.timeskew = server_time - int(time.time())
-                exp = time.time() + ASSERTION_LIFETIME + self.timeskew
-                assertion = browserid.tests.support.make_assertion(
-                    email=email,
-                    audience=self.server_url,
-                    issuer=MOCKMYID_DOMAIN,
-                    issuer_keypair=(None, MOCKMYID_PRIVATE_KEY),
-                    exp=int(exp * 1000),
+
+            if response is None:
+                raise ValueError(
+                    "Failed to get response from token server at {}".format(token_url)
                 )
-                response = json_request(token_url, headers={
-                    "Authorization": "BrowserID " + assertion,
-                })
 
-            if response['status'] > 299:
-                raise ValueError(response['status'])
+            if response.get('status') > 299:
+                error_msg = "Request with OAuth token failed with status {}: {}".format(
+                    response.get('status'),
+                    response
+                )
+                raise ValueError(error_msg)
 
-            credentials = response['content']
+            credentials = response.get('content')
+            if credentials is None:
+                raise ValueError(
+                    "Token response missing content. Response: {}".format(response)
+                )
+
             self.auth_token = credentials["id"].encode('ascii')
             self.auth_secret = credentials["key"].encode('ascii')
             self.endpoint_url = credentials["api_endpoint"]
@@ -254,3 +485,26 @@ class StorageClient(object):
 
     async def delete(self, path_qs, data=None, statuses=None, params=None):
         return await self._retry('DELETE', path_qs, params, data, statuses)
+
+    def cleanup(self):
+        """
+        Clean up the FxA account created for this test session.
+        """
+        if self.fxa_cleanup_info is None:
+            return
+
+        try:
+            self.fxa_cleanup_info['acct'].clear()
+
+            client = self.fxa_cleanup_info['client']
+            email = self.fxa_cleanup_info['email']
+            password = self.fxa_cleanup_info['password']
+
+            client.destroy_account(email, password)
+            _remove_account_from_tracking(email)
+
+            if os.environ.get("DEBUG_OAUTH"):
+                print(f"DEBUG: Deleted FxA account: {email} / {self.fxa_uid}")
+
+        except Exception as ex:
+            print(f"Warning: Encountered error when deleting FxA account {email} / {self.fxa_uid}: {ex}")


### PR DESCRIPTION
## Description

BrowserID is no longer supported.  This patch adds OAuth JWT support.

## Testing

See the readme.  Easiest would be using FxA stage.

## Issue(s)

Closes STOR-310